### PR TITLE
Enable User Configs to be Provided

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,9 @@ module github.com/LeviMatus/soundboard
 
 go 1.12
 
-require github.com/faiface/beep v1.0.1
+require (
+	github.com/faiface/beep v1.0.1
+	github.com/mitchellh/go-homedir v1.1.0
+	github.com/spf13/cobra v0.0.5
+	github.com/spf13/viper v1.4.0
+)

--- a/main.go
+++ b/main.go
@@ -5,15 +5,17 @@ import (
 	"fmt"
 	"github.com/LeviMatus/soundboard/pkg/sounds"
 	"github.com/LeviMatus/soundboard/pkg/webhook"
+	"github.com/spf13/viper"
 	"log"
 	"net/http"
 )
 
 var samples = make(chan string, 10)
+var users []sounds.User
 
 func handleWebhook(w http.ResponseWriter, r *http.Request) {
 	log.Println("got here")
-	samples <- "ending.mp3"
+
 	var b webhook.Webhook
 	err := json.NewDecoder(r.Body).Decode(&b)
 
@@ -22,11 +24,30 @@ func handleWebhook(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	for _, v := range users {
+		if v.IsUser(b.User) {
+			samples <- v.ClipName
+		}
+	}
+
 	fmt.Println("got webhook payload:")
 	fmt.Println(b.Issue.Fields.Points, b.User.Key, b.Issue.Fields.Status.Status)
 }
 
 func main() {
+
+	var v = viper.New()
+	v.SetConfigType("yaml")
+	v.SetConfigFile("sounds.yaml")
+	v.AddConfigPath("/home/levi/GolandProjects/soundboard")
+	v.ReadInConfig()
+
+	err := v.Unmarshal(&users)
+
+	if err != nil {
+		fmt.Println(err)
+	}
+
 	go sounds.Consume(samples)
 	log.Println("server started")
 	http.HandleFunc("/webhook", handleWebhook)

--- a/pkg/sounds/user.go
+++ b/pkg/sounds/user.go
@@ -1,0 +1,12 @@
+package sounds
+
+import "github.com/LeviMatus/soundboard/pkg/webhook"
+
+type User struct {
+	Name     string
+	ClipName string
+}
+
+func (u User) IsUser(ju webhook.User) bool {
+	return u.Name == ju.Name
+}


### PR DESCRIPTION
This PR adds the ability to specify a YAML file for configuration of users in JIRA. 

Requires users to provide a `sounds.yaml` file which will read users in and associate them with
different mp3 files to be played.